### PR TITLE
Handle EOF and empty input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ fn main() {
         print!("> ");
         io::stdout().flush().unwrap();
         let mut input = String::new();
-        io::stdin().read_line(&mut input).expect(".");
+        let bytes_read = io::stdin().read_line(&mut input).expect(".");
+        if bytes_read == 0 { /* EOF without any command. Exit */ break; }
         let child = ShellCommand::create(input);
         child.run();
     }

--- a/src/shell_command.rs
+++ b/src/shell_command.rs
@@ -17,6 +17,8 @@ impl ShellCommand {
     fn external_command(&self) {
         let child;
 
+        if &self.command == "" { return; }
+
         match &self.args {
             Some(args) => {
                 let processed_args: Vec<String> = args


### PR DESCRIPTION
Handles EOF by checking if bytes_read value, which is returned by read_line, is equal to zero.

Handles empty input by checking if the command is equal to "" in the external_command() function before execution.